### PR TITLE
Add github action for commitlint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,11 @@
+name: Lint Commit Messages
+on: [pull_request, push]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5


### PR DESCRIPTION
## First runs may fail

Due to certain permissions of github, it is likely that the first execution fails, to find a correct execution, certain settings must be modified in terms of the permissions of the actions.


***`Repo settings > Actions > Workflow permissions`***
![brave_JzWPikhmGi](https://github.com/ChirujanoCodding/Casio-theme/assets/71246795/53e96159-562e-4731-878d-89862275616f)

